### PR TITLE
Lite Caiman & Analysis merge into experiments

### DIFF
--- a/demos/sample_actors/process.py
+++ b/demos/sample_actors/process.py
@@ -196,11 +196,17 @@ class CaimanProcessor(Actor):
         dims = image.shape
         self._updateCoords(A, dims)
         t5 = time.time()
+        logger.info(f"frame no {self.frame_number}, we have {C.shape[0]} neurons")
+        if C.shape[1] > 500:
+            C_to_put = C[:, -500:]  #only sending the latest 500 frames?
+        else:
+            C_to_put = C
 
         ids = []
         ids.append(self.client.put(self.coords)) #, "coords" + str(self.frame_number)))
         ids.append(self.client.put(image)) #, "proc_image" + str(self.frame_number)))
-        ids.append(self.client.put(C)) #, "S" + str(self.frame_number)))
+        # ids.append(self.client.put(C)) #, "S" + str(self.frame_number)))
+        ids.append(self.client.put(C_to_put)) #, "S" + str(self.frame_number)))
         ids.append(self.frame_number)
         t6 = time.time()
 

--- a/demos/sample_actors/process.py
+++ b/demos/sample_actors/process.py
@@ -196,7 +196,7 @@ class CaimanProcessor(Actor):
         dims = image.shape
         self._updateCoords(A, dims)
         t5 = time.time()
-        logger.info(f"frame no {self.frame_number}, we have {C.shape[0]} neurons")
+        # logger.info(f"frame no {self.frame_number}, we have {C.shape[0]} neurons")
         if C.shape[1] > 500:
             C_to_put = C[:, -500:]  #only sending the latest 500 frames?
         else:

--- a/experiments/common_actors/analysis.py
+++ b/experiments/common_actors/analysis.py
@@ -25,7 +25,6 @@ class VizStimAnalysis(Actor):
         self.stimuli = self.stim_space['stimuli']
         self.d = self.stimuli.shape[0]
         self.param_space = self.stimuli_space.param_space
-        self.param_space_optim = self.stimuli_space.param_space_optim
         self.param_space_size = self.stimuli_space.param_space_size 
         self.param_index_space = self.stimuli_space.param_index_space
         # logger.info('reading in stim: {}'.format(self.stimuli))
@@ -86,6 +85,8 @@ class VizStimAnalysis(Actor):
         self.puttime = []
         self.colortime = []
         self.stimtime = []
+        self.putstimtime = []
+        self.getCtime = []
         self.timestamp = []
         self.LL = []
         self.fit_times = []
@@ -102,6 +103,11 @@ class VizStimAnalysis(Actor):
         np.savetxt('output/timing/analysis_timestamp.txt', np.array(self.timestamp))
         np.savetxt('output/analysis_estsAvg.txt', np.array(self.estsAvg))
         np.savetxt('output/analysis_proc_S.txt', np.array(self.S))
+        np.savetxt('output/timing/analysis_puttime.txt', np.array(self.puttime))
+        np.savetxt('output/timing/analysis_colortime.txt', np.array(self.colortime))
+        np.savetxt('output/timing/analysis_stimtime.txt', np.array(self.stimtime))
+        np.savetxt('output/timing/analysis_putstimtime.txt', np.array(self.putstimtime))
+        np.savetxt('output/timing/analysis_getCtime.txt', np.array(self.getCtime))
 
         with open("output/analysis_stimY.pkl", 'wb') as f:
             pickle.dump(self.stimY, f)
@@ -131,9 +137,11 @@ class VizStimAnalysis(Actor):
                 self.q_out.put([1])
                 raise Empty
             self.frame = ids[-1]
+            t_get = time.time()
             self.coordDict = self.client.get(ids[0])
             self.image = self.client.get(ids[1])
             self.S = self.client.get(ids[2])
+            self.getCtime.append(time.time()-t_get)
 
             self.C = self.S
             self.C = np.where(np.isnan(self.C), 0, self.C)
@@ -173,6 +181,9 @@ class VizStimAnalysis(Actor):
                     logger.error('Nan in Cpop')
                 self.Call = self.C #already a windowed version #[:,self.frame-window:self.frame]
 
+            # trim C all and C pop for faster communication
+            self.Call = self.Call[:, -len(self.Cx):]
+            self.Cpop = self.Cpop[-len(self.Cx):]
             self.putAnalysis()
             self.putStimulus()
 
@@ -235,6 +246,8 @@ class VizStimAnalysis(Actor):
         ''' Throw things to DS and put IDs in queue for Visual
         '''
         t = time.time()
+        # logger.info(f"Cx shape {self.Cx.shape}, Call shape {self.Call.shape}, Cpop shape {self.Cpop.shape}, tune shape {len(self.tune)} with len {self.tune[0].shape}, color shape {self.color.shape}, coordDict len {len(self.coordDict)}, allStims len {len(self.allStims)}")
+        
         ids = []
         ids.append(self.client.put(self.Cx))    #, 'Cx'+str(self.frame))) 
         ids.append(self.client.put(self.Call))  #, 'Call'+str(self.frame)))
@@ -253,6 +266,7 @@ class VizStimAnalysis(Actor):
     def putStimulus(self):
         ''' Throw things to DS and put IDS in queue for Optimizer
         '''
+        t = time.time()
         ids = []
         ids.append(self.client.put(self.stimX))   #, 'stimX'+str(self.frame)))
         ids.append(self.client.put(self.stimY))   #, 'stimY'+str(self.frame)))
@@ -260,6 +274,7 @@ class VizStimAnalysis(Actor):
         ids.append(self.client.put(self.testNum)) #, 'stim_testNum'+str(self.frame)))
         ids.append(self.client.put(self.nID))     #, 'stim_nID'+str(self.frame)))
         self.links['stim_out'].put(ids)
+        self.putstimtime.append(time.time()-t)
 
     def stimAvg_start(self): #TODO: need to rewrite this section (since ys will no longer be a dict)
         t = time.time()
@@ -272,23 +287,26 @@ class VizStimAnalysis(Actor):
             self.ests = np.pad(self.ests, ((0,diff),(0,0),(0,0)), mode='constant')
 
         if self.currentStim is not None:
+            s_idx = int(self.currentStim)
             if self.stimStart == self.frame:
 
-                mean_val = np.mean(ests[:, self.frame-self.before_amount:self.frame], 1)
+                mean_val = np.mean(ests[:, -self.before_amount:], 1)
 
                 self.ests[:, self.currentStim, 1] = (self.counter[self.currentStim, 1] * self.ests[:, self.currentStim, 1] + mean_val) / (self.counter[self.currentStim, 1] +1)
                 self.counter[self.currentStim, 1] += self.before_amount
             
             elif self.frame in range(self.stimStart+1, self.stimStart+2):
 
-                val = ests[:, self.frame-1]
+                # val = ests[:, self.frame-1]
+                val = ests[:, -2]
 
                 self.ests[:, self.currentStim, 1] = (self.counter[self.currentStim, 1] * self.ests[:, self.currentStim, 1] + val) / (self.counter[self.currentStim, 1] +1)
                 self.counter[self.currentStim, 1] += 1
             
             elif self.frame in range(self.stimStart+2, self.stimStart+self.after_amount):
 
-                val = ests[:, self.frame-1]
+                # val = ests[:, self.frame-1]
+                val = ests[:, -2]
 
                 self.ests[:, self.currentStim, 0] = (self.counter[self.currentStim, 0] * self.ests[:, self.currentStim, 0] + val) / (self.counter[self.currentStim, 0] +1)
                 self.counter[self.currentStim, 0] += 1
@@ -297,7 +315,7 @@ class VizStimAnalysis(Actor):
                 logger.info('appending to X: {}'.format(self.xs))
 
                 self.stimX.append(self.xs)
-                self.stimY.append(np.mean(ests[:, self.frame-self.after_amount:self.frame], 1))
+                self.stimY.append(np.mean(ests[:, -self.after_amount:], 1))
                 logger.info('we have {} neurons right now'.format(ests.shape[0]))
 
                 self.testNum += 1
@@ -305,8 +323,9 @@ class VizStimAnalysis(Actor):
                 
                 sc = self.stim_count[self.currentStim]
                 idx = int(self.currentStim)
+                logger.info(f"this is s_idx {s_idx}, this is idx {idx}, same? {s_idx == idx}")
                 self.all_y[:numN, idx] = ((sc-1) * self.all_y[:numN, idx] + self.stimY[-1]) / sc
-        
+
         self.estsAvg = np.squeeze(self.ests[:, :, 0] - self.ests[:, :, 1])
         self.estsAvg = np.where(np.isnan(self.estsAvg), 0, self.estsAvg)
         self.estsAvg[self.estsAvg == np.inf] = 0

--- a/experiments/common_actors/analysis.py
+++ b/experiments/common_actors/analysis.py
@@ -80,7 +80,6 @@ class VizStimAnalysis(Actor):
         self.testNum = 0 
         self.nID = 0
         self.stimText = None
-        # self.stimY_ls = []
 
         self.total_times = []
         self.puttime = []
@@ -114,8 +113,6 @@ class VizStimAnalysis(Actor):
             pickle.dump(self.stimY, f)
         with open("output/analysis_stimX.pkl", 'wb') as f:
             pickle.dump(self.stimX, f)
-        # with open("output/analysis_stimY_ls.pkl", 'wb') as f:
-        #     pickle.dump(self.stimY_ls, f)
             
         stim = []
         for i in self.allStims.keys():
@@ -347,8 +344,6 @@ class VizStimAnalysis(Actor):
 
                 # self.stimY.append(np.mean(ests[:, -self.after_amount:], 1))  # relative indexing
                 logger.info('at frame {} we have {} neurons right now'.format(self.frame, ests.shape[0]))
-                # self.stimY_ls.append(ests[:, -self.after_amount:])  # relative indexing
-                # self.stimY_ls.append(ests[:, local_start:local_end])  # absolute indexing
                 self.testNum += 1
                 numN = self.ests.shape[0]
                 

--- a/experiments/common_actors/analysis.py
+++ b/experiments/common_actors/analysis.py
@@ -80,6 +80,7 @@ class VizStimAnalysis(Actor):
         self.testNum = 0 
         self.nID = 0
         self.stimText = None
+        # self.stimY_ls = []
 
         self.total_times = []
         self.puttime = []
@@ -113,6 +114,8 @@ class VizStimAnalysis(Actor):
             pickle.dump(self.stimY, f)
         with open("output/analysis_stimX.pkl", 'wb') as f:
             pickle.dump(self.stimX, f)
+        # with open("output/analysis_stimY_ls.pkl", 'wb') as f:
+        #     pickle.dump(self.stimY_ls, f)
             
         stim = []
         for i in self.allStims.keys():
@@ -280,7 +283,9 @@ class VizStimAnalysis(Actor):
         t = time.time()
 
         ests = self.C
-        
+        buffer_len = ests.shape[1]
+        buffer_start_idx = max(0, self.frame - (buffer_len - 1))
+
         if self.ests.shape[0]<ests.shape[0]:
             diff = ests.shape[0] - self.ests.shape[0]
             # added more neurons, grow the array
@@ -288,36 +293,62 @@ class VizStimAnalysis(Actor):
 
         if self.currentStim is not None:
             s_idx = int(self.currentStim)
+            local_idx_now = self.frame - buffer_start_idx
             if self.stimStart == self.frame:
-
-                mean_val = np.mean(ests[:, -self.before_amount:], 1)
-
+                local_end = local_idx_now + 1
+                local_start = max(0, local_end - self.before_amount)
+               
+                # mean_val = np.mean(ests[:, -self.before_amount:], 1)  # relative indexing; need to be replaced
+                mean_val = np.mean(ests[:, local_start:local_end], 1)
                 self.ests[:, self.currentStim, 1] = (self.counter[self.currentStim, 1] * self.ests[:, self.currentStim, 1] + mean_val) / (self.counter[self.currentStim, 1] +1)
                 self.counter[self.currentStim, 1] += self.before_amount
             
             elif self.frame in range(self.stimStart+1, self.stimStart+2):
+                target_frame = self.frame - 1
+                local_idx = target_frame - buffer_start_idx
 
-                # val = ests[:, self.frame-1]
-                val = ests[:, -2]
+                if 0 <= local_idx < buffer_len:
+                    val = ests[:, local_idx]
+                    self.ests[:, self.currentStim, 1] = (self.counter[self.currentStim, 1] * self.ests[:, self.currentStim, 1] + val) / (self.counter[self.currentStim, 1] + 1)
+                    self.counter[self.currentStim, 1] += 1
+                else:
+                    logger.warning(f"Frame {target_frame} missing from 500-frame buffer.")
 
-                self.ests[:, self.currentStim, 1] = (self.counter[self.currentStim, 1] * self.ests[:, self.currentStim, 1] + val) / (self.counter[self.currentStim, 1] +1)
-                self.counter[self.currentStim, 1] += 1
-            
+                # # val = ests[:, self.frame-1]
+                # val = ests[:, -2]  # dont use relative indexing (caiman need to send an array of frame num)
+
+                # self.ests[:, self.currentStim, 1] = (self.counter[self.currentStim, 1] * self.ests[:, self.currentStim, 1] + val) / (self.counter[self.currentStim, 1] +1)
+                # self.counter[self.currentStim, 1] += 1
+
             elif self.frame in range(self.stimStart+2, self.stimStart+self.after_amount):
+                target_frame = self.frame - 1
+                local_idx = target_frame - buffer_start_idx
+                
+                if 0 <= local_idx < buffer_len:
+                    val = ests[:, local_idx]
+                    self.ests[:, self.currentStim, 0] = (self.counter[self.currentStim, 0] * self.ests[:, self.currentStim, 0] + val) / (self.counter[self.currentStim, 0] + 1)
+                    self.counter[self.currentStim, 0] += 1
+                else:
+                    logger.warning(f"Frame {target_frame} missing from 500-frame buffer.")
 
-                # val = ests[:, self.frame-1]
-                val = ests[:, -2]
+                # # val = ests[:, self.frame-1]
+                # val = ests[:, -2]  # same, dont use relative indexing
 
-                self.ests[:, self.currentStim, 0] = (self.counter[self.currentStim, 0] * self.ests[:, self.currentStim, 0] + val) / (self.counter[self.currentStim, 0] +1)
-                self.counter[self.currentStim, 0] += 1
+                # self.ests[:, self.currentStim, 0] = (self.counter[self.currentStim, 0] * self.ests[:, self.currentStim, 0] + val) / (self.counter[self.currentStim, 0] +1)
+                # self.counter[self.currentStim, 0] += 1
 
             if self.frame == self.stimStart + self.after_amount:
                 logger.info('appending to X: {}'.format(self.xs))
 
                 self.stimX.append(self.xs)
-                self.stimY.append(np.mean(ests[:, -self.after_amount:], 1))
-                logger.info('we have {} neurons right now'.format(ests.shape[0]))
+                local_end = local_idx_now + 1
+                local_start = max(0, local_end - self.after_amount)
+                self.stimY.append(np.mean(ests[:, local_start:local_end], 1))
 
+                # self.stimY.append(np.mean(ests[:, -self.after_amount:], 1))  # relative indexing
+                logger.info('at frame {} we have {} neurons right now'.format(self.frame, ests.shape[0]))
+                # self.stimY_ls.append(ests[:, -self.after_amount:])  # relative indexing
+                # self.stimY_ls.append(ests[:, local_start:local_end])  # absolute indexing
                 self.testNum += 1
                 numN = self.ests.shape[0]
                 


### PR DESCRIPTION
The increasing usage of memory and slower processing speed as the experiment progress is likely due to the increasing C array being sent from actor to actor. To fix that issue, I made the following changes:

- caiman only sent the latest 500 frames to analysis 
- analysis uses relative indexing to calculate the neuron responses over a period of time
- analysis only sent the latest 150 (or whatever self.Cx is set to) frames to visual
- also add a few more time tracking in analysis

