### PR TITLE
merge Index translation to experiments

### DIFF
--- a/experiments/common_actors/analysis.py
+++ b/experiments/common_actors/analysis.py
@@ -30,7 +30,7 @@ class VizStimAnalysis(Actor):
         self.param_space_optim = self.stimuli_space.r1_params #param_space_optim
         # logger.info('reading in stim: {}'.format(self.stimuli))
 
-
+        self.calibration_not_moving_dots = 0
         self.before_amount = before_amount
         self.after_amount = after_amount
         self.calc_color = calc_color
@@ -238,6 +238,9 @@ class VizStimAnalysis(Actor):
         frame = stim["frame"]
         whichStim = stim["indices"]
         tag = stim["tag"]
+        if tag == "calibration":
+            self.calibration_not_moving_dots += 1
+            logger.info(f"current frame {frame}, whichstim {whichStim}, tag {tag}, counting {self.calibration_not_moving_dots}")
         # logger.info('sig {}, frame {},  whichStim {}, tag {}'.format(stim, frame, whichStim, tag))
 
         self.current_stim = whichStim
@@ -305,6 +308,7 @@ class VizStimAnalysis(Actor):
         ids.append(self.client.put(self.frame))
         ids.append(self.client.put(self.testNum)) #, 'stim_testNum'+str(self.frame)))
         ids.append(self.client.put(self.nID))     #, 'stim_nID'+str(self.frame)))
+        ids.append(self.client.put(self.calibration_not_moving_dots))
         # ids.append(self.client.put(self.total_stim_counts))
         self.links['stim_out'].put(ids)
         self.putstimtime.append(time.time()-t)

--- a/experiments/common_actors/analysis.py
+++ b/experiments/common_actors/analysis.py
@@ -382,7 +382,7 @@ class VizStimAnalysis(Actor):
                 
                 sc = self.stim_count[self.currentStim]
                 idx = int(self.currentStim)
-                logger.info(f"this is s_idx {s_idx}, this is idx {idx}, same? {s_idx == idx}")
+                # logger.info(f"this is s_idx {s_idx}, this is idx {idx}, same? {s_idx == idx}")
                 self.all_y[:numN, idx] = ((sc-1) * self.all_y[:numN, idx] + self.stimY[-1]) / sc
 
         self.estsAvg = np.squeeze(self.ests[:, :, 0] - self.ests[:, :, 1])

--- a/experiments/common_actors/analysis.py
+++ b/experiments/common_actors/analysis.py
@@ -27,7 +27,7 @@ class VizStimAnalysis(Actor):
         self.param_space = self.stimuli_space.param_space
         self.param_space_size = self.stimuli_space.param_space_size 
         self.param_index_space = self.stimuli_space.param_index_space
-        self.param_space_optim = self.stimuli_space.param_space_optim
+        self.param_space_optim = self.stimuli_space.r1_params #param_space_optim
         # logger.info('reading in stim: {}'.format(self.stimuli))
 
 
@@ -242,12 +242,16 @@ class VizStimAnalysis(Actor):
 
         self.current_stim = whichStim
 
-        if tag == 'optim' or tag == 'initial':
+        if tag == 'optim' or tag == 'initial' or tag == 'calibration_initial' or tag == 'random' or tag == 'grid':
             params = self.param_space_optim[whichStim]
             multi_idx = self.stimuli_space.param_to_idx(params, tag=tag)
 
         else:
             multi_idx = self.param_index_space[whichStim]
+            # multi_idx_copy = multi_idx.copy()
+            # if self.stimuli_space.map_full_to_r1[whichStim] >= 0:
+            #     # multi_idx = self.stimuli_space.r1_coords[self.stimuli_space.map_full_to_r1[whichStim]]
+            #     logger.info(f"AHAHAHAHAH multi_idx remapping this was multi_idx {multi_idx_copy}, and this is multi_idx {multi_idx}")
         multi_idx = np.asarray(multi_idx, dtype=int)
         logger.info('multi_idx: {}'.format(multi_idx))
 

--- a/experiments/common_actors/optimizer.py
+++ b/experiments/common_actors/optimizer.py
@@ -90,9 +90,7 @@ class BayesOptimizer(Actor):
 
         self.calibration = calibration
         logger.info('calibration is {}'.format(self.stim_space['calibration_stim']))
-        self.calibration_display = self.calibration
         self.tag_to_go = "calibration"
-        logger.info(f'calibration display is {self.calibration_display}')
 
 
     def setup(self):
@@ -133,6 +131,7 @@ class BayesOptimizer(Actor):
             ids = self.q_in.get(timeout=0.0001)
             X = self.client.get(ids[0])
             Y = self.client.get(ids[1])
+            self.calibration_not_moving_dots = self.client.get(ids[-1])
             # stim_count = self.client.get(ids[-1]) # -1 to account for initial stim
             # logger.info('X, Y: {}, {}'.format(X, Y))
 
@@ -237,10 +236,10 @@ class BayesOptimizer(Actor):
         elif self.newN:
             logger.info("Reducing X from 8D to 5D for optimization - init")
             # logger.info(f"here is x_all yo: {self.X_all}")
-            if self.calibration_display:
-                logger.info(f"Have calibration stimuli, need to ignore the first 13 non-moving dots stimuli as well as related responses")
-                self.X_all = self.X_all[:, 13:]  # TODO: this is hard-coded; need to change later?
-                self.y0 = self.y0[:, 13:]
+            if self.calibration_not_moving_dots > 0:
+                logger.info(f"Have calibration stimuli, need to ignore the first {self.calibration_not_moving_dots} non-moving dots stimuli as well as related responses")
+                self.X_all = self.X_all[:, self.calibration_not_moving_dots:]  # TODO: this is hard-coded; need to change later?
+                self.y0 = self.y0[:, self.calibration_not_moving_dots:]
                 # logger.info(f"after trimming this is shape of self.x_all {self.X_all.shape} the sahpe of y0 {self.y0.shape}")
             self.X = self.stimuli_space.param_space_shrinking(self.X_all) 
             # logger.info('self.X in INITIALIZATION is {} and has shape {} - init'.format(self.X, self.X.shape))
@@ -756,8 +755,6 @@ class RandomSamplerWithReplace(Actor):
         self.calibration = calibration
         if self.calibration:
             logger.info('calibration set is: {}'.format(self.stim_space['calibration_stim']))
-        self.calibration_display = self.calibration
-        logger.info(f'calibration display is {self.calibration_display}')
 
     def setup(self):
     
@@ -963,7 +960,8 @@ class RandomBayesOptimizer(Actor):
             ids = self.q_in.get(timeout=0.0001)
             X = self.client.get(ids[0])
             Y = self.client.get(ids[1])
-            stim_count = self.client.get(ids[-1]) # -1 to account for initial stim
+            self.calibration_not_moving_dots = self.client.get(ids[-1])
+            # stim_count = self.client.get(ids[-1]) # -1 to account for initial stim
             tmpX = np.squeeze(np.array(X)).T
             sh = len(tmpX.shape)
             if sh > 1:
@@ -977,7 +975,7 @@ class RandomBayesOptimizer(Actor):
                 self.y0 = b.T
                 is_nan_2d = np.isnan(self.y0)
                 self.start_stimulus = np.argmax(~is_nan_2d, axis=1)
-                self.stim_count = stim_count-1
+                # self.stim_count = stim_count-1
             except:
                 pass
         except Empty:
@@ -1077,10 +1075,10 @@ class RandomBayesOptimizer(Actor):
             # This block corresponds to 'elif self.newN:' from the original BayesOptimizer
             if self.bayes_newN:
                 logger.info("Reducing X from 8D to 5D for optimization - init")
-                if self.calibration_display:
-                    logger.info(f"Have calibration stimuli, need to ignore the first 13 non-moving dots/ dots with different indexing stimuli which is {self.X_all[:, :13]}")
-                    self.X_all = self.X_all[:, 13:]  # TODO: this is hard-coded; need to change later?
-                    self.y0 = self.y0[:, 13:]
+                if self.calibration_not_moving_dots > 0:
+                    logger.info(f"Have calibration stimuli, need to ignore the first {self.calibration_not_moving_dots} non-moving dots/ dots with different indexing stimuli which is {self.X_all[:, :13]}")
+                    self.X_all = self.X_all[:, self.calibration_not_moving_dots:]  # TODO: this is hard-coded; need to change later?
+                    self.y0 = self.y0[:, self.calibration_not_moving_dots:]
                 self.X = self.stimuli_space.param_space_shrinking(self.X_all) 
                 nonopt = np.array(list(set(np.arange(self.y0.shape[0]))-set(self.optimized_n)))
                 logger.info('nonopt is {}, number of neurons '.format(nonopt,self.y0.shape[0]))

--- a/experiments/common_actors/optimizer.py
+++ b/experiments/common_actors/optimizer.py
@@ -1080,6 +1080,7 @@ class RandomBayesOptimizer(Actor):
                 if self.calibration_display:
                     logger.info(f"Have calibration stimuli, need to ignore the first 13 non-moving dots/ dots with different indexing stimuli which is {self.X_all[:, :13]}")
                     self.X_all = self.X_all[:, 13:]  # TODO: this is hard-coded; need to change later?
+                    self.y0 = self.y0[:, 13:]
                 self.X = self.stimuli_space.param_space_shrinking(self.X_all) 
                 nonopt = np.array(list(set(np.arange(self.y0.shape[0]))-set(self.optimized_n)))
                 logger.info('nonopt is {}, number of neurons '.format(nonopt,self.y0.shape[0]))

--- a/experiments/common_actors/optimizer.py
+++ b/experiments/common_actors/optimizer.py
@@ -349,7 +349,7 @@ class BayesOptimizer(Actor):
                 ids.append(self.client.put(curr_est)) #, 'est'))
                 ids.append(self.client.put(curr_unc)) #, 'unc'))
                 self.q_out.put(ids)
-
+                logger.info(f"anything weird/ nan in curr_est? {np.isnan(curr_est).any()} what about curr_unc {np.isnan(curr_unc).any()}")
                 stopCrit, PI = self.optim.stopping()
                 logger.info('----------- stopCrit: {}'.format(stopCrit))
                 self.stopping[self.test_count] = stopCrit
@@ -572,7 +572,7 @@ class GridSampler(Actor):
             self.stimuli_optim[1][[0, 2, 5]],      # speed -> [0.02, 0.06, 0.12]
             self.stimuli_optim[2][[0, 2, 4]],      # size -> [50, 225, 400]
             self.stimuli_optim[3][[1, 3]],         # frequency -> [3, 20]
-            self.stimuli_optim[4][0, 2] #[[0, 1, 2]]       # contrast -> [0, 50, 100]
+            self.stimuli_optim[4][[0, 2]] #[[0, 1, 2]]       # contrast -> [0, 50, 100]
         ]
         logger.info(f"self.stimuli_reduced is {self.stimuli_reduced}")
         self.total_stim_time = self.stim_space['total_stim_time']
@@ -684,7 +684,12 @@ class GridSampler(Actor):
         elif self.newN:
             if self.stim_ind is None:
                 logger.info('grid')
-                grid = self.stim_star_reduced[self.counter]  # FIXME: this is grid not random
+                if self.counter < self.stim_star_reduced.shape[0]:
+                    grid = self.stim_star_reduced[self.counter]  # FIXME: this is grid not random
+                else:
+                    logger.info(f"!!!!!!!SELF.COUNTER {self.counter} EXCEED THE GRID LENGTH, STOP NOW!!!!!!!")
+                    grid = self.stim_star[self.counter]
+                # grid = self.stim_star_reduced[self.counter]  # FIXME: this is grid not random
                 self.stim_ind = self.stimuli_space.param_to_ridx(grid, tag='grid')
 
                 #FIXME: make checkpoints here and read all possible dimensions
@@ -696,7 +701,7 @@ class GridSampler(Actor):
                 # param4 = np.argwhere(int(grid[4]) == self.stimuli_optim[4])[0][0]
 
                 # self.stim_ind = [param0, param1, param2, param3, param4]
-                logger.info('grid stimulus indices chosen: {}'.format(self.stim_ind))
+                logger.info('grid stimulus indices chosen: {} with counter {} and grid {}'.format(self.stim_ind, self.counter, grid))
 
             if (time.time() - self.timer) >= self.total_stim_time:
                 self.links['stim_ind_out'].put([self.stim_ind, 'grid'])

--- a/experiments/common_actors/optimizer.py
+++ b/experiments/common_actors/optimizer.py
@@ -91,6 +91,7 @@ class BayesOptimizer(Actor):
         self.calibration = calibration
         logger.info('calibration is {}'.format(self.stim_space['calibration_stim']))
         self.calibration_display = self.calibration
+        self.tag_to_go = "calibration"
         logger.info(f'calibration display is {self.calibration_display}')
 
 
@@ -173,9 +174,16 @@ class BayesOptimizer(Actor):
                 logger.info('Calibration counter is {}/{}'.format(self.counter+1, len(self.stim_space['calibration_stim'])))
                 self.stim_ind = self.stim_space['calibration_stim'][self.counter]
                 logger.info('calibration_stim set: {}'.format(self.stim_ind))
+                # logger.info(f"what is this?? {self.stimuli_space.map_full_to_r1[self.stim_ind]}")
+                if self.stimuli_space.map_full_to_r1[self.stim_ind] >= 0:
+                    self.tag_to_go = "calibration_initial"
+                    # logger.info(f"HEYYYY optimizer is remapping the tags yooo, now it's {self.tag_to_go}")
+                else:
+                    # logger.info(f"calibration calibration, this is the index {self.stimuli_space.param_index_space[self.stim_ind]}")
+                    self.tag_to_go = "calibration"
             
             if (time.time() - self.timer) >= self.total_stim_time:
-                self.links['stim_ind_out'].put([self.stim_ind, 'calibration'])
+                self.links['stim_ind_out'].put([self.stim_ind, self.tag_to_go])
                 # stim_flag = 'calibration'
                 # self.links['stim_flag_out'].put(stim_flag)
                 self.stim_ind = None
@@ -230,10 +238,10 @@ class BayesOptimizer(Actor):
             logger.info("Reducing X from 8D to 5D for optimization - init")
             # logger.info(f"here is x_all yo: {self.X_all}")
             if self.calibration_display:
-                logger.info(f"Have calibration stimuli, need to ignore the first 16 non-moving dots stimuli which is {self.X_all[:, :16]}")
-                self.X_all = self.X_all[:, 16:]  # TODO: this is hard-coded; need to change later?
+                logger.info(f"Have calibration stimuli, need to ignore the first 13 non-moving dots stimuli which is {self.X_all[:, :13]}")
+                self.X_all = self.X_all[:, 13:]  # TODO: this is hard-coded; need to change later?
             self.X = self.stimuli_space.param_space_shrinking(self.X_all) 
-            # logger.info('self.X in INITIALIZATION is {} and has shape {} - init'.format(self.X, self.X.shape))
+            logger.info('self.X in INITIALIZATION is {} and has shape {} - init'.format(self.X, self.X.shape))
 
             nonopt = np.array(list(set(np.arange(self.y0.shape[0]))-set(self.optimized_n)))
             logger.info('nonopt is {}, number of neurons {}'.format(nonopt,self.y0.shape[0]))
@@ -470,9 +478,15 @@ class RandomSampler(Actor):
                 logger.info('Calibration counter is {}/{}'.format(self.counter+1, len(self.stim_space['calibration_stim'])))
                 self.stim_ind = self.stim_space['calibration_stim'][self.counter]
                 logger.info('calibration_stim set: {}'.format(self.stim_ind))
+                if self.stimuli_space.map_full_to_r1[self.stim_ind] >= 0:
+                    self.tag_to_go = "calibration_initial"
+                    # logger.info(f"HEYYYY optimizer is remapping the tags yooo, now it's {self.tag_to_go}")
+                else:
+                    # logger.info(f"calibration calibration, this is the index {self.stimuli_space.param_index_space[self.stim_ind]}")
+                    self.tag_to_go = "calibration"
             
             if (time.time() - self.timer) >= self.total_stim_time:
-                self.links['stim_ind_out'].put([self.stim_ind, 'calibration'])
+                self.links['stim_ind_out'].put([self.stim_ind, self.tag_to_go])
                 self.stim_ind = None
                 self.counter += 1
                 self.timer = time.time()
@@ -516,9 +530,10 @@ class RandomSampler(Actor):
         elif self.newN:
             if self.stim_ind is None:
                 logger.info('random')
-                # random_stim = self.stim_star_shuffle[self.counter]
+                random_stim = self.stim_star_shuffle[self.counter]
+                self.stim_ind = self.stimuli_space.param_to_ridx(random_stim, tag = "random")
                 # TODO: actually will just need to send a random row index it's not that deep bro
-                self.stim_ind = np.random.randint(0, self.stimuli_optim.shape[0])
+                # self.stim_ind = np.random.randint(0, self.stimuli_optim.shape[0])  # this is actually incorrect
 
                 # #FIXME: make checkpoints here and read all possible dimensions
                 # #FIXME: This is a manual method (need to fix to make it more flexible)
@@ -532,7 +547,7 @@ class RandomSampler(Actor):
                 logger.info('random stimulus indices chosen: {}'.format(self.stim_ind))
 
             if (time.time() - self.timer) >= self.total_stim_time:
-                self.links['stim_ind_out'].put([self.stim_ind, 'optim'])
+                self.links['stim_ind_out'].put([self.stim_ind, 'random'])
                 self.stim_ind = None
                 self.counter += 1
                 self.newN = True
@@ -557,7 +572,7 @@ class GridSampler(Actor):
             self.stimuli_optim[1][[0, 2, 5]],      # speed -> [0.02, 0.06, 0.12]
             self.stimuli_optim[2][[0, 2, 4]],      # size -> [50, 225, 400]
             self.stimuli_optim[3][[1, 3]],         # frequency -> [3, 20]
-            self.stimuli_optim[4][[0, 1, 2]]       # contrast -> [0, 50, 100]
+            self.stimuli_optim[4][0, 2] #[[0, 1, 2]]       # contrast -> [0, 50, 100]
         ]
         logger.info(f"self.stimuli_reduced is {self.stimuli_reduced}")
         self.total_stim_time = self.stim_space['total_stim_time']
@@ -617,14 +632,20 @@ class GridSampler(Actor):
                 logger.info('Calibration counter is {}/{}'.format(self.counter+1, len(self.stim_space['calibration_stim'])))
                 self.stim_ind = self.stim_space['calibration_stim'][self.counter]
                 logger.info('calibration_stim set: {}'.format(self.stim_ind))
+                if self.stimuli_space.map_full_to_r1[self.stim_ind] >= 0:
+                    self.tag_to_go = "calibration_initial"
+                    # logger.info(f"HEYYYY optimizer is remapping the tags yooo, now it's {self.tag_to_go}")
+                else:
+                    # logger.info(f"calibration calibration, this is the index {self.stimuli_space.param_index_space[self.stim_ind]}")
+                    self.tag_to_go = "calibration"
             
             if (time.time() - self.timer) >= self.total_stim_time:
-                self.links['stim_ind_out'].put([self.stim_ind, 'calibration'])
+                self.links['stim_ind_out'].put([self.stim_ind, self.tag_to_go])
                 self.stim_ind = None
                 self.counter += 1
                 self.timer = time.time()
             
-            if self.counter >= 5: #self.stimuli_space.calibration_stim_count:
+            if self.counter >= self.stimuli_space.calibration_stim_count:
                 flag = True
             
             if flag:
@@ -664,7 +685,7 @@ class GridSampler(Actor):
             if self.stim_ind is None:
                 logger.info('grid')
                 grid = self.stim_star_reduced[self.counter]  # FIXME: this is grid not random
-                self.stim_ind = self.stimuli_space.param_to_ridx(grid, tag='optim')
+                self.stim_ind = self.stimuli_space.param_to_ridx(grid, tag='grid')
 
                 #FIXME: make checkpoints here and read all possible dimensions
                 #FIXME: This is a manual method (need to fix to make it more flexible)
@@ -678,7 +699,7 @@ class GridSampler(Actor):
                 logger.info('grid stimulus indices chosen: {}'.format(self.stim_ind))
 
             if (time.time() - self.timer) >= self.total_stim_time:
-                self.links['stim_ind_out'].put([self.stim_ind, 'optim'])
+                self.links['stim_ind_out'].put([self.stim_ind, 'grid'])
                 self.stim_ind = None
                 self.counter += 1
                 self.newN = True
@@ -757,14 +778,20 @@ class RandomSamplerWithReplace(Actor):
                 logger.info('Calibration counter is {}/{}'.format(self.counter+1, len(self.stim_space['calibration_stim'])))
                 self.stim_ind = self.stim_space['calibration_stim'][self.counter]
                 logger.info('calibration_stim set: {}'.format(self.stim_ind))
+                if self.stimuli_space.map_full_to_r1[self.stim_ind] >= 0:
+                    self.tag_to_go = "calibration_initial"
+                    # logger.info(f"HEYYYY optimizer is remapping the tags yooo, now it's {self.tag_to_go}")
+                else:
+                    # logger.info(f"calibration calibration, this is the index {self.stimuli_space.param_index_space[self.stim_ind]}")
+                    self.tag_to_go = "calibration"
             
             if (time.time() - self.timer) >= self.total_stim_time:
-                self.links['stim_ind_out'].put([self.stim_ind, 'calibration'])
+                self.links['stim_ind_out'].put([self.stim_ind, self.tag_to_go])
                 self.stim_ind = None
                 self.counter += 1
                 self.timer = time.time()
             
-            if self.counter >= 5: #self.stimuli_space.calibration_stim_count:
+            if self.counter >= self.stimuli_space.calibration_stim_count:
                 flag = True
             
             if flag:
@@ -818,7 +845,7 @@ class RandomSamplerWithReplace(Actor):
                 logger.info('random stimulus indices chosen: {}'.format(self.stim_ind))
 
             if (time.time() - self.timer) >= self.total_stim_time:
-                self.links['stim_ind_out'].put([self.stim_ind, 'optim'])
+                self.links['stim_ind_out'].put([self.stim_ind, 'random'])
                 self.stim_ind = None
                 self.counter += 1
                 self.newN = True
@@ -962,16 +989,22 @@ class RandomBayesOptimizer(Actor):
                 logger.info('Calibration counter is {}/{}'.format(self.counter+1, len(self.stim_space['calibration_stim'])))
                 self.stim_ind = self.stim_space['calibration_stim'][self.counter]
                 logger.info('calibration_stim set: {}'.format(self.stim_ind))
+                if self.stimuli_space.map_full_to_r1[self.stim_ind] >= 0:
+                    self.tag_to_go = "calibration_initial"
+                    # logger.info(f"HEYYYY optimizer is remapping the tags yooo, now it's {self.tag_to_go}")
+                else:
+                    # logger.info(f"calibration calibration, this is the index {self.stimuli_space.param_index_space[self.stim_ind]}")
+                    self.tag_to_go = "calibration"
             
             if (time.time() - self.timer) >= self.total_stim_time:
-                self.links['stim_ind_out'].put([self.stim_ind, 'calibration'])
+                self.links['stim_ind_out'].put([self.stim_ind, self.tag_to_go])
                 # stim_flag = 'calibration'
                 # self.links['stim_flag_out'].put(stim_flag)
                 self.stim_ind = None
                 self.counter += 1
                 self.timer = time.time()
             
-            if self.counter >= 5: #self.stimuli_space.calibration_stim_count:
+            if self.counter >= self.stimuli_space.calibration_stim_count:
                 flag = True
             
             if flag:
@@ -1022,7 +1055,7 @@ class RandomBayesOptimizer(Actor):
 
             if (time.time() - self.timer) >= self.total_stim_time:
                 logger.info(f"sending {self.stim_ind} to stimulus actor ")
-                self.links['stim_ind_out'].put([self.stim_ind, 'optim'])
+                self.links['stim_ind_out'].put([self.stim_ind, 'random'])
                 self.stim_ind = None
                 self.counter += 1
                 self.timer = time.time()
@@ -1038,8 +1071,8 @@ class RandomBayesOptimizer(Actor):
             if self.bayes_newN:
                 logger.info("Reducing X from 8D to 5D for optimization - init")
                 if self.calibration_display:
-                    logger.info(f"Have calibration stimuli, need to ignore the first 16 non-moving dots/ dots with different indexing stimuli which is {self.X_all[:, :16]}")
-                    self.X_all = self.X_all[:, 16:]  # TODO: this is hard-coded; need to change later?
+                    logger.info(f"Have calibration stimuli, need to ignore the first 13 non-moving dots/ dots with different indexing stimuli which is {self.X_all[:, :13]}")
+                    self.X_all = self.X_all[:, 13:]  # TODO: this is hard-coded; need to change later?
                 self.X = self.stimuli_space.param_space_shrinking(self.X_all) 
                 nonopt = np.array(list(set(np.arange(self.y0.shape[0]))-set(self.optimized_n)))
                 logger.info('nonopt is {}, number of neurons '.format(nonopt,self.y0.shape[0]))

--- a/experiments/common_actors/optimizer.py
+++ b/experiments/common_actors/optimizer.py
@@ -238,10 +238,12 @@ class BayesOptimizer(Actor):
             logger.info("Reducing X from 8D to 5D for optimization - init")
             # logger.info(f"here is x_all yo: {self.X_all}")
             if self.calibration_display:
-                logger.info(f"Have calibration stimuli, need to ignore the first 13 non-moving dots stimuli which is {self.X_all[:, :13]}")
+                logger.info(f"Have calibration stimuli, need to ignore the first 13 non-moving dots stimuli as well as related responses")
                 self.X_all = self.X_all[:, 13:]  # TODO: this is hard-coded; need to change later?
+                self.y0 = self.y0[:, 13:]
+                # logger.info(f"after trimming this is shape of self.x_all {self.X_all.shape} the sahpe of y0 {self.y0.shape}")
             self.X = self.stimuli_space.param_space_shrinking(self.X_all) 
-            logger.info('self.X in INITIALIZATION is {} and has shape {} - init'.format(self.X, self.X.shape))
+            # logger.info('self.X in INITIALIZATION is {} and has shape {} - init'.format(self.X, self.X.shape))
 
             nonopt = np.array(list(set(np.arange(self.y0.shape[0]))-set(self.optimized_n)))
             logger.info('nonopt is {}, number of neurons {}'.format(nonopt,self.y0.shape[0]))

--- a/experiments/savier/actors/acquire_zmq.py
+++ b/experiments/savier/actors/acquire_zmq.py
@@ -313,10 +313,10 @@ class ZMQAcquirer(Actor):
             if speed == float(0):
                 logger.info('Stimulus: Flashing spot at ({},{}) at frame {}'.format(center_x, center_y, self.frame_num))
             else:
-                if angle in [45, 135, 225, 315]:
-                    # Adjust angle to match stimulus space, remapping to the "center" of the stimulus screen
-                    center_x = 850
-                    center_y = 1000
+                # if angle in [45, 135, 225, 315]:
+                #     # Adjust angle to match stimulus space, remapping to the "center" of the stimulus screen
+                #     center_x = 850
+                #     center_y = 1000
                 logger.info('Stimulus: {} Moving dots with size {} at angle {} and speed {} with contrast {} at frame {}'.format(freq, size, angle, speed, contrast, self.frame_num))
 
 

--- a/experiments/savier/actors/acquire_zmq.py
+++ b/experiments/savier/actors/acquire_zmq.py
@@ -337,7 +337,7 @@ class ZMQAcquirer(Actor):
 
         stim_set_tag = msg_dict['stimulus']['note']
         indices = self.stimuli_space.param_to_ridx([angle, speed, size, freq, center_x, center_y, contrast, shape], tag=stim_set_tag)
-        
+        # logger.info(f"{[angle, speed, size, freq, center_x, center_y, contrast, shape]}")
         # self.links['stim_queue'].put({self.frame_num:indices})
         self.links['stim_queue'].put({"frame": self.frame_num,"indices": indices,"tag": stim_set_tag})
         self.stimmed.append([self.frame_num, angle, speed, size, freq, center_x, center_y, contrast, shape])

--- a/experiments/savier/actors/stimulus.py
+++ b/experiments/savier/actors/stimulus.py
@@ -103,34 +103,34 @@ class VisualStimulus(Actor):
 
         if stim is not None:
 
-            if self.speed == float(0):
-                center_x = self.center_x
-                center_y = self.center_y
-            else:
-            #NOTE: this is hardcoded for specific directions and their most visible "center" point on the visible grid (this will move to experiments folder)
-                if self.angle == 45:
-                    center_x = 80
-                    center_y = 1400
-                elif self.angle == 135:
-                    center_x = 750
-                    center_y = 1500
-                elif self.angle == 225:
-                    center_x = 350
-                    center_y = 1000
-                elif self.angle == 315:
-                    center_x = 1400
-                    center_y = 1500
-                else:
-                    center_x = 850
-                    center_y = 1000
+            # if self.speed == float(0):
+            #     center_x = self.center_x
+            #     center_y = self.center_y
+            # else:
+            # #NOTE: this is hardcoded for specific directions and their most visible "center" point on the visible grid (this will move to experiments folder)
+            #     if self.angle == 45:
+            #         center_x = 80
+            #         center_y = 1400
+            #     elif self.angle == 135:
+            #         center_x = 750
+            #         center_y = 1500
+            #     elif self.angle == 225:
+            #         center_x = 350
+            #         center_y = 1000
+            #     elif self.angle == 315:
+            #         center_x = 1400
+            #         center_y = 1500
+            #     else:
+            #         center_x = 850
+            #         center_y = 1000
 
             if self.shape == 0:
                 texture_name = 'gray_ellipse'
                 
                 text = {'texture_size': 1600,
                         'frequency': int(self.frequency),
-                        'center_x': center_x,
-                        'center_y': center_y,
+                        'center_x': self.center_x,
+                        'center_y': self.center_y,
                         'width': int(self.size), 
                         'length': int(self.size),
                         'texture_name': texture_name,
@@ -173,7 +173,9 @@ class VisualStimulus(Actor):
             'angle': 45, 
             'speed': 0.02,
             'size': 50, 
-            'frequency': 1, 
+            'frequency': 1,
+            'center_x': 800,
+            'center_y': 800, 
             'contrast': 50,
             'shape': 0,
         }

--- a/experiments/savier/actors/stimulus.py
+++ b/experiments/savier/actors/stimulus.py
@@ -78,11 +78,11 @@ class VisualStimulus(Actor):
             t = time.time()
             row_index, tag = self.links['stim_ind_in'].get(timeout=0.0001) #TODO: need to confirm if this row_index makes sense
             logger.info('stim index: {}'.format(row_index))
-            if tag == 'optim' or tag == 'initial' or tag == 'calibration_initial' or tag == 'random':
+            if tag == 'optim' or tag == 'initial' or tag == 'calibration_initial' or tag == 'random' or tag == "grid":
                 logger.info(f"from stimulius actor we got tag {tag}")
                 parameters = self.stimuli_space.ridx_to_param(row_index, tag=tag)
             else: 
-                parameters = self.stimuli_space.ridx_to_param(row_index, tag='non_optim') 
+                parameters = self.stimuli_space.ridx_to_param(row_index, tag='calibration')#'non_optim') 
             logger.info('parameters: {}'.format(parameters))
             stim = self.create_frame(parameters, tag=tag)
 

--- a/experiments/savier/actors/stimulus.py
+++ b/experiments/savier/actors/stimulus.py
@@ -78,7 +78,8 @@ class VisualStimulus(Actor):
             t = time.time()
             row_index, tag = self.links['stim_ind_in'].get(timeout=0.0001) #TODO: need to confirm if this row_index makes sense
             logger.info('stim index: {}'.format(row_index))
-            if tag == 'optim' or tag == 'initial':
+            if tag == 'optim' or tag == 'initial' or tag == 'calibration_initial' or tag == 'random':
+                logger.info(f"from stimulius actor we got tag {tag}")
                 parameters = self.stimuli_space.ridx_to_param(row_index, tag=tag)
             else: 
                 parameters = self.stimuli_space.ridx_to_param(row_index, tag='non_optim') 

--- a/experiments/savier/bayesopt_parameters.yaml
+++ b/experiments/savier/bayesopt_parameters.yaml
@@ -14,6 +14,7 @@ Stimuli:
 
 Optimizer:
   n: 1  # only for counting optimizers, differ from d
+  mse_cutoff: 0.5
   gamma: 1 #1e-1 #1
   var: 0.5
   nu: 0.5 #1e-1

--- a/experiments/savier/bayesopt_parameters.yaml
+++ b/experiments/savier/bayesopt_parameters.yaml
@@ -1,7 +1,7 @@
 General:
   seed: 42
-  init_T: 4
-  max_tests: 5 #15
+  init_T: 8
+  max_tests: 15
   improv: True
 
 Stimuli:
@@ -20,5 +20,5 @@ Optimizer:
   eta: 5e-2
   optim_1:
     kernel: ['rbf', 'rbf', 'rbf', 'rbf', 'rbf']  
-    stopping_crit: 4e-4 #3e-4 
+    stopping_crit: 3e-4 #3e-4 
   

--- a/experiments/savier/gen_stim.py
+++ b/experiments/savier/gen_stim.py
@@ -91,7 +91,7 @@ class StimulusSpace():
             calibration_stim.append(row_index)
         
         stationary_spots = [[0,0,0,0,1,1,1,0], [0,0,0,0,0,2,1,0], [0,0,0,0,2,2,1,0], [0,0,0,0,2,0,1,0], [0,0,0,0,0,0,1,0]]
-        moving_spots = [[i,2,0,1,0,0,1,0] for i in range(0,6,2)]
+        moving_spots = [[i,2,0,1,1,1,1,0] for i in range(0,6,2)]
         spots = stationary_spots + moving_spots
 
         for params in spots:
@@ -239,6 +239,3 @@ class StimulusSpace():
         # r1 to r2 mapping
         self.map_r1_to_r2 = np.full(len(self.r1_coords), -1)
         self.map_r1_to_r2[self.idx_r2_to_r1] = np.arange(len(self.idx_r2_to_r1))
-
-
-s = StimulusSpace()

--- a/experiments/savier/gen_stim.py
+++ b/experiments/savier/gen_stim.py
@@ -39,19 +39,24 @@ class StimulusSpace():
         param_space, idx = np.unique(temp, axis=0, return_index=True)
         self.param_space = param_space
         self.param_space_size = self.param_space.shape[0]
-        self.param_index_space = param_index_space_full[idx]
+        self.param_index_space = param_index_space_full[idx]  # this is the full index space
 
-        # param_space_optim (this will not include drift gratings or flashing spots, only moving dots)
-        mask_dg = np.any(param_space == -99, axis=1)
-        mask_fs = param_space[:, 1] == float(0)
-        mask1 = mask_dg | mask_fs
+        # # param_space_optim (this will not include drift gratings or flashing spots, only moving dots)
+        # mask_dg = np.any(param_space == -99, axis=1)
+        # mask_fs = param_space[:, 1] == float(0)
+        # mask1 = mask_dg | mask_fs
 
-        param_space_optim = self.param_space[~mask1]
-        mask_center_x = param_space_optim[:,4] == 850
-        mask_center_y = param_space_optim[:,5] == 1000
-        mask_shape = param_space_optim[:,7] == 0
-        mask2 = mask_center_x & mask_center_y & mask_shape
-        self.param_space_optim = param_space_optim[mask2]
+        # param_space_optim = self.param_space[~mask1]
+        # mask_center_x = param_space_optim[:,4] == 850
+        # mask_center_y = param_space_optim[:,5] == 1000
+        # mask_shape = param_space_optim[:,7] == 0
+        # mask2 = mask_center_x & mask_center_y & mask_shape
+        # self.param_space_optim = param_space_optim[mask2]
+        # logger.info(f"param_space_optim shape {self.param_space_optim.shape}: {self.param_space_optim}")
+
+        self.translation()
+
+        # logger.info(f"param_space and r2_param same? {np.array_equal(self.param_space_optim, self.r2_params)}")
 
         calibration_stim, self.calibration_stim_count = self.calibration_stim(self.stim)
 
@@ -74,6 +79,7 @@ class StimulusSpace():
             'hold_after': hold_after,
             'stat_t': stationary_t, 
         }
+        logger.info(f"stim_space: {self.stim_space}")
 
     #FIXME: need to put these functions into index space 
     def calibration_stim(self, stim):
@@ -92,6 +98,10 @@ class StimulusSpace():
             param = self.idx_to_param(params, tag = 'calibration')
             row_index = self.param_to_ridx(param, tag='calibration')
             calibration_stim.append(row_index)
+            # logger.info(f"{self.map_full_to_r1[row_index]}")
+            # if self.map_full_to_r1[row_index] >= 0:
+            #     logger.info(f"params is {params}, row_idx is {row_index}, remapped? is {self.map_full_to_r1[row_index]}, {self.r1_params[self.map_full_to_r1[row_index]]}")
+            
 
         return calibration_stim, len(calibration_stim)
 
@@ -113,9 +123,9 @@ class StimulusSpace():
     def param_to_idx(self, stimuli, tag):
         # translation from parameter space to index space
         indices = []
-        if tag == 'optim' or tag == 'initial':
+        if tag == 'optim' or tag == 'initial' or tag == "calibration_initial" or tag == 'random' or tag == 'grid':
             space = self.stim_optim_space
-        else:
+        else:  # calibration 
             space = self.stim
 
         for d, stim in enumerate(stimuli):
@@ -144,22 +154,43 @@ class StimulusSpace():
     
     def param_to_ridx(self, stimuli, tag):
 
-        if tag == 'optim' or tag == 'initial':
+        if tag == 'optim' or tag == 'initial' or tag == 'random' or tag == 'grid':
             if isinstance(stimuli, np.ndarray) and stimuli.shape[0] == 5:
+                # logger.info(f"stimuli before extending: {stimuli}")
                 extended_stim = np.concatenate([stimuli[:4], [850, 1000], stimuli[4:], [0]])
-                row_index = np.argwhere((extended_stim == self.param_space_optim).all(axis=1))[0][0]
+                # logger.info(f"stimuli after extending: {extended_stim}")
+                row_index = self.idx_r2_to_r1[np.argwhere((extended_stim == self.r2_params).all(axis=1))[0][0]]
+                # # self.idx_r2_to_r1
+                # extended_stim = np.concatenate([stimuli[:4], [850, 1000], stimuli[4:], [0]])
+                # row_index = np.argwhere((extended_stim == self.param_space_optim).all(axis=1))[0][0]  # TODO: translation happens here
 
             else:
-                row_index = np.argwhere((stimuli == self.param_space_optim).all(axis=1))[0][0]
-        else:
+                row_index = np.argwhere((stimuli == self.r1_params).all(axis=1))[0][0]
+                # row_index = np.argwhere((stimuli == self.param_space_optim).all(axis=1))[0][0]  # TODO: translation happens here
+        elif tag == "calibration_initial":
             row_index = np.argwhere((stimuli == self.param_space).all(axis=1))[0][0]
-
+            row_index = self.map_full_to_r1[row_index]
+            # logger.info(f"remapping HAPPENING the new row_index is {self.r1_params[row_index]} and index of {self.r1_coords[row_index]}")
+        else:  # calibration
+            row_index = np.argwhere((stimuli == self.param_space).all(axis=1))[0][0]
+            # if self.map_full_to_r1[row_index] >= 0:
+            #     # row_index = np.argwhere((stimuli == self.r1_params).all(axis=1))[0][0]
+            #     logger.info(f"remapping IMAGING the new row_index is {self.r1_params[self.map_full_to_r1[row_index]]} and index of {self.map_full_to_r1[row_index]}")
+                
         return row_index
 
     def ridx_to_param(self, row_index, tag):
         
-        if tag == 'optim' or tag == 'initial':
-            stimuli = self.param_space_optim[row_index]
+        if tag == 'optim':
+            # extended_row_index = np.concatenate([row_index[:4], [1, 1], row_index[4:], [0]])
+            stimuli = self.r2_params[row_index]
+        elif tag == 'initial' or tag == 'random' or tag == 'grid':
+            stimuli = self.r1_params[row_index]
+            # stimuli = self.param_space_optim[row_index] # TODO: translation happens here
+        elif tag == 'calibration_initial':
+            # logger.info("blurrrrrr")
+            stimuli = self.r1_params[self.map_full_to_r1[row_index]]
+            # stimuli = self.r1_params[row_index]
         else:
             stimuli = self.param_space[row_index]
 
@@ -177,3 +208,34 @@ class StimulusSpace():
         stimuli_optim = np.delete(stim_set_copy, [4,5,7], axis=0) 
 
         return stimuli_optim
+    
+    def translation(self):
+        # mapping from full space to R1 (all moving dots)
+        mask_r1 = (self.param_index_space[:, 7] != 1) & (self.param_index_space[:, 1] != 0)
+
+        # r1 to full
+        self.idx_r1_to_full = np.where(mask_r1)[0]
+        # logger.info(f"idx_r1_to_full shape {self.idx_r1_to_full.shape}: {self.idx_r1_to_full}")
+        # self.map_r1_to_full = self.idx_r1_to_full
+        self.r1_coords = self.param_index_space[mask_r1].copy()
+        self.r1_coords[:, 1] -= 1  # to account for the speed dimension
+        self.r1_params = self.param_space[mask_r1].copy()  # all subspace?
+        # logger.info(f"r1_coords shape {self.r1_coords.shape}: {self.r1_coords}")
+        # logger.info(f"r1_params shape {self.r1_params.shape}: {self.r1_params}")
+
+        # r2 to r1
+        mask_r2_within_r1 = (self.r1_coords[:, 4] == 1) & (self.r1_coords[:, 5] == 1)
+        self.idx_r2_to_r1 = np.where(mask_r2_within_r1)[0]
+        self.r2_coords = self.r1_coords[self.idx_r2_to_r1].copy()
+        self.r2_params = self.r1_params[self.idx_r2_to_r1].copy()  # 2880, 8
+
+
+        # full to r1 mapping
+        self.map_full_to_r1 = np.full(len(self.param_index_space), -1)
+        self.map_full_to_r1[self.idx_r1_to_full] = np.arange(len(self.idx_r1_to_full))
+        
+        # r1 to r2 mapping
+        self.map_r1_to_r2 = np.full(len(self.r1_coords), -1)
+        self.map_r1_to_r2[self.idx_r2_to_r1] = np.arange(len(self.idx_r2_to_r1))
+
+

--- a/experiments/savier/gen_stim.py
+++ b/experiments/savier/gen_stim.py
@@ -11,7 +11,7 @@ class StimulusSpace():
         x2 = np.array([0.0, 0.02, 0.04, 0.06, 0.08, 0.10, 0.12]) 
         x3 = np.array([50, 137, 225, 312, 400])
         x4 = np.array([1, 3, 10, 20])
-        x5 = np.array([250, 850, 1450])
+        x5 = np.array([250, 850, 1200]) #1450])
         x6 = np.array([600, 1000, 1300])
         x7 = np.array([0, 50, 100])
         x8 = np.array([0,1])

--- a/experiments/savier/gen_stim.py
+++ b/experiments/savier/gen_stim.py
@@ -10,9 +10,9 @@ class StimulusSpace():
         x1 = np.array([0, 45, 90, 135, 180, 225, 270, 315]) 
         x2 = np.array([0.0, 0.02, 0.04, 0.06, 0.08, 0.10, 0.12]) 
         x3 = np.array([50, 137, 225, 312, 400])
-        x4 = np.array([1, 3, 10, 20])
-        x5 = np.array([250, 850, 1200]) #1450])
-        x6 = np.array([600, 1000, 1300])
+        x4 = np.array([1, 7, 39, 95])
+        x5 = np.array([100, 800, 1500]) #1450])
+        x6 = np.array([450, 800, 1150])
         x7 = np.array([0, 50, 100])
         x8 = np.array([0,1])
 
@@ -85,7 +85,7 @@ class StimulusSpace():
     def calibration_stim(self, stim):
         
         calibration_stim = []
-        drift_grating = self.param_space[(self.param_space[:,7] == 1) & (self.param_space[:,1] == 0.02) & (self.param_space[:,3] == 3) & (self.param_space[:,6] == 50)]
+        drift_grating = self.param_space[(self.param_space[:,7] == 1) & (self.param_space[:,1] == 0.02) & (self.param_space[:,3] == 7) & (self.param_space[:,6] == 50)]
         for param in drift_grating:
             row_index = self.param_to_ridx(param, tag = 'calibration')
             calibration_stim.append(row_index)
@@ -241,3 +241,4 @@ class StimulusSpace():
         self.map_r1_to_r2[self.idx_r2_to_r1] = np.arange(len(self.idx_r2_to_r1))
 
 
+s = StimulusSpace()

--- a/experiments/savier/gen_stim.py
+++ b/experiments/savier/gen_stim.py
@@ -210,18 +210,20 @@ class StimulusSpace():
         return stimuli_optim
     
     def translation(self):
+        '''
+        "Translating" between full space and 2 subspaces (R1 and R2). 
+        R1 is the subspace containing all moving dots (with shape 25920,8)
+        R2 is ths subspace containing all moving dots with fixed center_x and center_y (with shape 2880, 8)
+        '''
+
         # mapping from full space to R1 (all moving dots)
         mask_r1 = (self.param_index_space[:, 7] != 1) & (self.param_index_space[:, 1] != 0)
 
         # r1 to full
         self.idx_r1_to_full = np.where(mask_r1)[0]
-        # logger.info(f"idx_r1_to_full shape {self.idx_r1_to_full.shape}: {self.idx_r1_to_full}")
-        # self.map_r1_to_full = self.idx_r1_to_full
         self.r1_coords = self.param_index_space[mask_r1].copy()
         self.r1_coords[:, 1] -= 1  # to account for the speed dimension
         self.r1_params = self.param_space[mask_r1].copy()  # all subspace?
-        # logger.info(f"r1_coords shape {self.r1_coords.shape}: {self.r1_coords}")
-        # logger.info(f"r1_params shape {self.r1_params.shape}: {self.r1_params}")
 
         # r2 to r1
         mask_r2_within_r1 = (self.r1_coords[:, 4] == 1) & (self.r1_coords[:, 5] == 1)

--- a/experiments/savier/live_caiman_params.yaml
+++ b/experiments/savier/live_caiman_params.yaml
@@ -1,6 +1,6 @@
 data:
   fr: 7.5 #15 #2.2
-  decay_time: 0.5 #0.5
+  decay_time: 1.5 #0.5
   fnames: ['output/initialization.h5']
 
 init: 

--- a/experiments/savier/savier_simulate.yaml
+++ b/experiments/savier/savier_simulate.yaml
@@ -4,21 +4,21 @@ actors:
     class: DisplayVisual
     visual: Visual
 
-  Microscope:
-    package: experiments.common_actors.load_disc
-    class: FileAcquirer
-    ip: '*'
-    port: 5007
-    output: output/
-    init_filename: output/initialization.h5
-    filename: data/sample_stream0.h5
-    init_frame: 0 #60
-    framerate: 7.5
+  # Microscope:
+  #   package: experiments.common_actors.load_disc
+  #   class: FileAcquirer
+  #   ip: '*'
+  #   port: 5007
+  #   output: output/
+  #   init_filename: output/initialization.h5
+  #   filename: data/sample_stream0.h5
+  #   init_frame: 0 #60
+  #   framerate: 7.5
 
   Acquirer:
       package: actors.acquire_zmq
       class: ZMQAcquirer
-      ip: 127.0.0.1 #192.168.1.1 #127.0.0.1 IP address is for running a pseudo-online run
+      ip: 192.168.1.1 #127.0.0.1 IP address is for running a pseudo-online run
       ports: [50154, 5000,5007,5008,5009,5010,5011,4701,4703,5865,5005,5017,5018] 
       output: output/
       red_chan_image: output/red_channel_image.npy
@@ -52,9 +52,9 @@ actors:
 
   Optimizer:
     package: experiments.common_actors.optimizer
-    class: BayesOptimizer
+    class: BayesOptimizer #GridSampler #RandomSampler #BayesOptimizer
     param_file: bayesopt_parameters.yaml
-    calibration: True
+    calibration: False #True
 
 connections:
   Acquirer.q_out: [Processor.q_in, Visual.raw_frame_queue]

--- a/experiments/savier/savier_simulate.yaml
+++ b/experiments/savier/savier_simulate.yaml
@@ -54,7 +54,7 @@ actors:
     package: experiments.common_actors.optimizer
     class: BayesOptimizer #GridSampler #RandomSampler #BayesOptimizer
     param_file: bayesopt_parameters.yaml
-    calibration: False #True
+    calibration: True #True
 
 connections:
   Acquirer.q_out: [Processor.q_in, Visual.raw_frame_queue]


### PR DESCRIPTION
This branch contains codes to make sure there's a consistent translation between indices across full space and 2 subspaces:

- A new translation function that translates the index between difference spaces.
- new tags ("random", "grid", "calibration_initial") are created to be associated with different scenarios (stimulus selected by `randomSampler`, `gridSampler`, or calibration stim that can be used for GP initialization)
- `Analysis` actor counts the number of "calibration" (drift gratings and flashing spots) stimuli and sends the count to `optimizer`. `Optimizer` uses the number (instead of a hard coding) to crop out the X and y for GP initialization

Other changes includes 1. re-added fallback for `gridSampler` after we're done with subsamples; 2. fixed the `randomSampler` bug; 3. cleaned out some redundant logger statements.